### PR TITLE
Add fontmake build scripts

### DIFF
--- a/sources/scripts/build.sh
+++ b/sources/scripts/build.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -e
+
+glyphsSource="ElMessiri"
+outputDir="fonts/vf"
+familyName="ElMessiri"
+
+echo "[INFO] Starting build script for $familyName font family"
+
+if [ -d .git ]; then
+  echo "[TEST] Running from a Git root directory, looks good"
+else
+  echo "[WARN] Font family Git root not found, please run from the root directory"
+  echo "[WARN] Build process cancelled"
+  exit 1
+fi
+
+echo "[INFO] Making 'fonts/vf' directory if it doesn't already exist"
+mkdir -p -v fonts/vf
+
+for i in $glyphsSource; do
+  echo "[TEST] Queued source file: $i.glyphs"
+done
+
+for i in $glyphsSource; do
+  echo "[INFO] Building $i.glyphs with Fontmake, this might take some time..."
+  fontmake -g sources/$i.glyphs -o variable \
+    --output-path $outputDir/$i-VF.ttf \
+    --verbose ERROR
+done
+
+echo "[INFO] Removing build directories"
+rm -rf instance_ufo master_ufo
+
+echo "[INFO] Fixing DSIG table"
+if gftools fix-dsig -f fonts/vf/$familyName-VF.ttf ; then
+  echo "[INFO] DSIG fixed"
+else
+  echo "[ERROR] GFtools is not working, please update or install: https://github.com/googlefonts/gftools"
+fi
+
+echo "[INFO] Autohinting with ttfautohint"
+if ttfautohint fonts/vf/$familyName-VF.ttf fonts/vf/$familyName-VF-FIX.ttf ; then
+  echo "[INFO] Autohinting completed"
+  echo "[INFO] Replacing unhinted fonts with hinted fonts"
+  mv fonts/vf/$familyName-VF-FIX.ttf fonts/vf/$familyName-VF.ttf 
+  echo "[INFO] Fixing hinting with GFtools"
+  gftools fix-hinting fonts/vf/$familyName-VF.ttf
+  mv fonts/vf/$familyName-VF.ttf.fix fonts/vf/$familyName-VF.ttf
+else
+  echo "[ERROR] ttfautohint is not working, please update or install: https://www.freetype.org/ttfautohint/"
+fi
+
+echo "[INFO] Done building $familyName font family"

--- a/sources/scripts/pull-request.sh
+++ b/sources/scripts/pull-request.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+prDir="~/Google/fonts/ofl/"
+familyName="ElMessiri"
+
+echo "[INFO] Preparing a new $familyName pull request at $prDir"
+
+cp fonts/vf/$familyName-VF.ttf ~/Google/fonts/ofl/elmessiri/$familyName[wght].ttf
+
+echo "[INFO] Done preparing $familyName pull request at $prDir"


### PR DESCRIPTION
Scripts for building with [fontmake](https://github.com/googlefonts/fontmake) and updating the Google Fonts repo. I have been running them both at the same time from the root directory, like this:
```
sources/scripts/build.sh && sources/scripts/pull-request.sh
```

```
new file:   sources/scripts/build.sh
            This is a basic build script for fontmake
            Run from the root directory

new file:   sources/scripts/pull-request.sh
            This script prepares a PR to Google Fonts
            Run from the root directory after running build.sh
```

Thanks! I can make a PR adding build instructions to the README or docs if you want.